### PR TITLE
[palette] introduce color_index class instead of short

### DIFF
--- a/examples/gallery/main.cxx
+++ b/examples/gallery/main.cxx
@@ -18,8 +18,10 @@ struct empty_item {
 
     void draw(int line, bool selected, ncursespp::rect_i r) const
     {
-        auto color = line % 2 ? 1 : 2;
-        color = selected ? 3 : color;
+        using namespace ncursespp;
+
+        auto color = line % 2_idx ? 1_idx : 2_idx;
+        color = selected ? 3_idx : color;
 
         ncursespp::draw::fill_rect(r, color);
     }
@@ -55,13 +57,13 @@ int main()
 
     auto left_panel = hsplit {
         ct::fixed<15>(list),
-        ct::fill(color_rect{5})
+        ct::fill(color_rect{5_idx})
     };
 
     auto vs = vsplit {
         ct::fixed<20>(left_panel),
-        ct::fixed<1>(color_rect{5}),
-        ct::fill(text{generate_text(), 1})
+        ct::fixed<1>(color_rect{5_idx}),
+        ct::fill(text{generate_text(), 1_idx})
     };
 
     for (int i = 0; i < 10; i ++) {

--- a/include/ncurses++/color_rect.hpp
+++ b/include/ncurses++/color_rect.hpp
@@ -3,6 +3,7 @@
 
 #include <ncurses++/rect.hpp>
 #include <ncurses++/widget.hpp>
+#include <ncurses++/palette.hpp>
 
 namespace ncursespp
 {
@@ -10,7 +11,7 @@ namespace ncursespp
 class color_rect : public widget<color_rect>
 {
 public:
-    color_rect(short c)
+    color_rect(color_index c)
         : color_ {c}
     {}
 
@@ -21,7 +22,7 @@ public:
 
 private:
     void redraw(rect_i r);
-    short color_;
+    color_index color_;
 };
 
 } // namespace ncursespp

--- a/include/ncurses++/drawing.hpp
+++ b/include/ncurses++/drawing.hpp
@@ -3,14 +3,15 @@
 
 #include <ncurses++/rect.hpp>
 #include <ncurses++/attributes.hpp>
+#include <ncurses++/palette.hpp>
 
 namespace ncursespp
 {
 
 struct draw
 {
-    static void fill_rect(rect_i r, short color);
-    static int text(const std::string &text, rect_i r, short color);
+    static void fill_rect(rect_i r, color_index color);
+    static int text(const std::string &text, rect_i r, color_index color);
     static void attribute_on(attribute attr);
     static void attribute_off(attribute attr);
 };

--- a/include/ncurses++/palette.hpp
+++ b/include/ncurses++/palette.hpp
@@ -9,11 +9,14 @@ namespace ncursespp
 {
 
 template<int I>
+struct color_index_constant : std::integral_constant<int, I> {};
+
+template<int I>
 struct color_pair
 {
     template<int Index>
     constexpr color_pair(
-            std::integral_constant<int, Index>,
+            color_index_constant<Index>,
             color FG,
             color BG
         )
@@ -24,6 +27,19 @@ struct color_pair
     static constexpr int pair = I;
     color fg;
     color bg;
+};
+
+struct color_index
+{
+    template<int Index> color_index(color_index_constant<Index>)
+        : index {Index}
+    {}
+
+    color_index(int index)
+        : index (index)
+    {}
+
+    int index;
 };
 
 template<class IntConst>
@@ -40,7 +56,7 @@ constexpr int accumulate_chars(std::initializer_list<char> chs)
 template<char... C>
 constexpr auto operator"" _idx ()
 {
-    return std::integral_constant<int, accumulate_chars({C...})>{};
+    return color_index_constant<accumulate_chars({C...})>{};
 }
 
 namespace detail

--- a/include/ncurses++/text.hpp
+++ b/include/ncurses++/text.hpp
@@ -3,6 +3,7 @@
 
 #include <ncurses++/rect.hpp>
 #include <ncurses++/widget.hpp>
+#include <ncurses++/palette.hpp>
 #include <string>
 
 namespace ncursespp
@@ -11,7 +12,7 @@ namespace ncursespp
 class text : public widget<text>
 {
 public:
-    text(std::string text, short c)
+    text(std::string text, color_index c)
         : text_ {std::move(text)}
         , color_ {c}
     {
@@ -21,7 +22,7 @@ public:
 
 private:
     std::string text_;
-    short color_;
+    color_index color_;
 };
 
 } // namespace ncursespp

--- a/include/ncurses++/text_list.hpp
+++ b/include/ncurses++/text_list.hpp
@@ -5,6 +5,7 @@
 #include <ncurses++/rect.hpp>
 #include <ncurses++/constraints.hpp>
 #include <ncurses++/widget.hpp>
+#include <ncurses++/palette.hpp>
 #include <string>
 #include <vector>
 #include <initializer_list>
@@ -16,7 +17,7 @@ namespace detail
 class text_list_base : public widget<text_list_base>
 {
 public:
-    text_list_base(short c1, short c2, short s);
+    text_list_base(color_index c1, color_index c2, color_index s);
 
     void append(std::string item);
     void append(std::initializer_list<std::string> items);
@@ -29,9 +30,9 @@ private:
     void draw_one(rect_i r, int line) const;
 
 private:
-    short color1_;
-    short color2_;
-    short colorHighlight_;
+    color_index color1_;
+    color_index color2_;
+    color_index colorHighlight_;
     std::vector<std::string> items_;
     int selected_;
     int displayPosition_;
@@ -42,7 +43,7 @@ private:
 class text_list : public detail::text_list_base
 {
 public:
-    text_list(short c1, short c2, short s)
+    text_list(color_index c1, color_index c2, color_index s)
         : text_list_base{c1, c2, s}
     {}
 };

--- a/src/drawing.cxx
+++ b/src/drawing.cxx
@@ -28,12 +28,12 @@ auto attributes_enum_to_ncurses(ncursespp::attribute attr)
 namespace ncursespp
 {
 
-void draw::fill_rect(rect_i r, short color)
+void draw::fill_rect(rect_i r, color_index color)
 {
     auto lt = r.left_top;
     auto rb = r.right_bottom;
 
-    attron(COLOR_PAIR(color));
+    attron(COLOR_PAIR(color.index));
 
     for (int x = lt.x; x <= rb.x; ++x) {
         for (int y = lt.y; y <= rb.y; ++y) {
@@ -41,23 +41,23 @@ void draw::fill_rect(rect_i r, short color)
         }
     }
 
-    attroff(COLOR_PAIR(color));
+    attroff(COLOR_PAIR(color.index));
 }
 
-int draw::text(const std::string &text, rect_i r, short color)
+int draw::text(const std::string &text, rect_i r, color_index color)
 {
     auto lt = r.left_top;
     int res = 0;
     fill_rect(r, color); // TODO: optimize!
 
-    attron(COLOR_PAIR(color));
+    attron(COLOR_PAIR(color.index));
     for (auto i = 0u;
          static_cast<int>(i) < r.width() && i < text.size();
          ++i) {
         mvaddch(lt.y, lt.x + i, text[i]);
         res ++;
     }
-    attroff(COLOR_PAIR(color));
+    attroff(COLOR_PAIR(color.index));
     return res;
 }
 

--- a/src/text.cxx
+++ b/src/text.cxx
@@ -11,7 +11,7 @@ void text::do_resize(rect_i r)
 
     auto p = r.left_top;
     auto i = 0u;
-    attron(COLOR_PAIR(color_));
+    attron(COLOR_PAIR(color_.index));
 
     while (text_[i] != '\0') {
         if (p.y > r.right_bottom.y) {
@@ -35,7 +35,7 @@ void text::do_resize(rect_i r)
         p.x ++;
     }
 
-    attroff(COLOR_PAIR(color_));
+    attroff(COLOR_PAIR(color_.index));
 }
 
 } // namespace ncurses

--- a/src/text_list.cxx
+++ b/src/text_list.cxx
@@ -4,7 +4,7 @@
 namespace ncursespp::detail
 {
 
-text_list_base::text_list_base(short c1, short c2, short s)
+text_list_base::text_list_base(color_index c1, color_index c2, color_index s)
     : color1_ {c1}
     , color2_ {c2}
     , colorHighlight_ {s}


### PR DESCRIPTION
Partially implements issue #5 but do not introduce custom colors with init_color